### PR TITLE
Roadmap: publish Bee v2.8 (released) + v2.8.1 (in progress), shift planned themes forward

### DIFF
--- a/src/content/items/bee-v2.8.1.md
+++ b/src/content/items/bee-v2.8.1.md
@@ -1,7 +1,13 @@
 ---
-title: "Pullsync improvements"
-subtitle: "More performant chunk synchronization between full nodes"
-status: to-do
+title: "Bee v2.8.1"
+subtitle: "Crash-safe storage, client-side stamp signing for browser uploads, and performance improvements."
+status: in-progress
 ---
 
-More performant chunk synchronization between full nodes.
+Bee v2.8.1 is a non-disruptive release (no breaking P2P changes) focused on durability, browser uploads, and efficiency. Node operators should upgrade.
+
+* Crash-safe local storage — chunks are validated against their content hashes on recovery, and corrupted ones are removed.
+* Client-side postage stamp signing — browsers can upload directly to Swarm without sharing keys with a node.
+* Performance — opt-in SIMD-accelerated hashing (Linux x86-64), reused handshake records, and fewer RPC calls via local block-time estimates.
+* New API endpoints — batch lookup (`GET /batches/{id}`), batch label updates (`PATCH /stamps/{id}`), and chainstate validity data.
+* Removed `bee dev` (use Bee Factory or Sepolia); nodes on v2.6.0 must upgrade via v2.8.0 first.

--- a/src/content/items/bee-v2.8.2.md
+++ b/src/content/items/bee-v2.8.2.md
@@ -1,7 +1,7 @@
 ---
-title: "PSS improvements"
-subtitle: "Fixing the case of missed messages when the node is not listening"
+title: "Scaleability improvements"
+subtitle: "Hardening and maintenance of core components to optimize the Swarm network"
 status: to-do
 ---
 
-Fixing the case of missed messages when the node is not listening.
+Hardening and maintenance of core components to optimize the Swarm network.

--- a/src/content/items/bee-v2.8.3.md
+++ b/src/content/items/bee-v2.8.3.md
@@ -1,7 +1,7 @@
 ---
-title: "In-browser and mobile node support"
-subtitle: "Architectural and network changes to support connections from various environments"
+title: "Pullsync improvements"
+subtitle: "More performant chunk synchronization between full nodes"
 status: to-do
 ---
 
-Architectural and network changes to support connections from various environments.
+More performant chunk synchronization between full nodes.

--- a/src/content/items/bee-v2.8.4.md
+++ b/src/content/items/bee-v2.8.4.md
@@ -1,7 +1,7 @@
 ---
-title: "Identity management support"
-subtitle: "Providing client side primitives for decoupling the Ethereum identity from the node"
+title: "PSS improvements"
+subtitle: "Fixing the case of missed messages when the node is not listening"
 status: to-do
 ---
 
-Providing client side primitives for decoupling the Ethereum identity from the node.
+Fixing the case of missed messages when the node is not listening.

--- a/src/content/items/bee-v2.8.5.md
+++ b/src/content/items/bee-v2.8.5.md
@@ -1,7 +1,7 @@
 ---
-title: "Micropayment solution"
-subtitle: "Experimental x402 support for flexible payments between users and services"
+title: "In-browser and mobile node support"
+subtitle: "Architectural and network changes to support connections from various environments"
 status: to-do
 ---
 
-Experimental x402 support for flexible payments between users and services.
+Architectural and network changes to support connections from various environments.

--- a/src/content/items/bee-v2.8.6.md
+++ b/src/content/items/bee-v2.8.6.md
@@ -1,0 +1,7 @@
+---
+title: "Identity management support"
+subtitle: "Providing client side primitives for decoupling the Ethereum identity from the node"
+status: to-do
+---
+
+Providing client side primitives for decoupling the Ethereum identity from the node.

--- a/src/content/items/bee-v2.8.7.md
+++ b/src/content/items/bee-v2.8.7.md
@@ -1,0 +1,7 @@
+---
+title: "Micropayment solution"
+subtitle: "Experimental x402 support for flexible payments between users and services"
+status: to-do
+---
+
+Experimental x402 support for flexible payments between users and services.

--- a/src/content/items/bee-v2.8.md
+++ b/src/content/items/bee-v2.8.md
@@ -1,6 +1,13 @@
 ---
-title: "Scaleability improvements"
-subtitle: "Hardening and maintenance of core components to optimize the Swarm network"
-status: to-do
+title: "Bee v2.8"
+subtitle: "Strengthens how nodes verify each other, with P2P hardening and a toolchain refresh."
+status: done
 ---
-Hardening and maintenance of core components to optimize the Swarm network.
+
+[Bee v2.8](https://github.com/ethersphere/bee/releases/tag/v2.8.0) strengthens peer verification and hardens the networking layer. It raises the handshake and hive protocols, so it requires a network-wide upgrade — older nodes can no longer handshake with v2.8 nodes.
+
+* Stronger peer address records — a signed timestamp and chequebook address, with the overlay nonce now part of the signature, verified before a record is stored.
+* Optional on-chain chequebook verification (opt-in, off by default) before a peer is trusted.
+* Caps on peer underlay address lists, keeping handshake and gossip messages bounded.
+* Configurable blockchain RPC transport, improved gas estimation, and faster node shutdown.
+* Toolchain refresh: Go 1.26 and the latest libp2p.

--- a/src/content/milestones/milestone-3.md
+++ b/src/content/milestones/milestone-3.md
@@ -9,4 +9,6 @@ items:
   - bee-v283
   - bee-v284
   - bee-v285
+  - bee-v286
+  - bee-v287
 ---


### PR DESCRIPTION
## What

Move the roadmap forward now that **Bee v2.8 is released** and **v2.8.1 ships ~1 July**, while keeping all the planned improvement themes.

- **Bee v2.8** → converted from the "Scaleability improvements" placeholder to a released entry (`status: done`), with the real v2.8.0 highlights and GitHub link.
- **Bee v2.8.1** → new released-style entry (`status: in-progress` until release day, then flip to `done`), summarizing the actual 2.8.1 contents (crash-safe storage, client-side stamp signing, performance, new APIs).
- **All six planned themes are kept** and shifted down two slots so they sit after the releases (order preserved):

| Slot | Title | Status |
|------|-------|--------|
| bee-v2.8 | **Bee v2.8** | done |
| bee-v2.8.1 | **Bee v2.8.1** | in-progress |
| bee-v2.8.2 | Scaleability improvements | to-do |
| bee-v2.8.3 | Pullsync improvements | to-do |
| bee-v2.8.4 | PSS improvements | to-do |
| bee-v2.8.5 | In-browser and mobile node support | to-do |
| bee-v2.8.6 | Identity management support | to-do |
| bee-v2.8.7 | Micropayment solution | to-do |

## On release day (~1 July)
Flip `bee-v2.8.1.md` `status: in-progress` → `done` and add `[Bee v2.8.1](https://github.com/ethersphere/bee/releases/tag/v2.8.1)`.

## Notes
- Content verified against the [v2.8.0 release notes](https://github.com/ethersphere/bee/releases/tag/v2.8.0) and the v2.8.1 blog post.
- Planned-theme titles are version-agnostic, so shifting their file ids is invisible on the page.
